### PR TITLE
Fix Chinese decoding

### DIFF
--- a/flanker/mime/message/charsets.py
+++ b/flanker/mime/message/charsets.py
@@ -23,7 +23,12 @@ def convert_to_unicode(charset, value):
 def _ensure_charset(charset):
     charset = charset.lower()
     try:
-        codecs.lookup(charset)
+        info = codecs.lookup(charset)
+        # Occasionally, the encoding for a GBK/GB 18030 string is incorrectly
+        # specified as GB 2312. Since GB 18030 is compatible with GB 2312 and
+        # GBK, we can use that.
+        if info.name in ('gb2312', 'gbk'):
+            return 'gb18030'
         return charset
     except LookupError:
         pass

--- a/flanker/mime/message/headers/parametrized.py
+++ b/flanker/mime/message/headers/parametrized.py
@@ -213,7 +213,7 @@ def decode_charset(parameter):
     if len(parts) != 3:
         return v
     charset, language, val = parts
-    val = urllib_parse.unquote(val)
+    val = urllib_parse.unquote_to_bytes(val)
     return charsets.convert_to_unicode(charset, val)
 
 

--- a/tests/mime/message/headers/encodedword_test.py
+++ b/tests/mime/message/headers/encodedword_test.py
@@ -113,7 +113,7 @@ def hotmail_encodings_test():
     eq_(u"Это сообщение с длинным сабжектом специально чтобы проверить кодировки", encodedword.mime_to_unicode(v))
 
 
-def various_encodings_test():
+def test_various_encodings():
     v = '"=?utf-8?b?6ICD5Y+W5YiG5Lqr?=" <foo@example.com>'
     eq_(u'"考取分享" <foo@example.com>', encodedword.mime_to_unicode(v))
 
@@ -137,6 +137,15 @@ def various_encodings_test():
 
     v = u'=?gb18030?Q?Hey_There=D7=B2=D8=B0?='
     eq_(u'Hey There撞匕', encodedword.mime_to_unicode(v))
+
+    v = u'=?gb2312?Q?Hey_There=2D=8C=8D=BE=B0?='
+    eq_(u'Hey There-實景', encodedword.mime_to_unicode(v))
+
+    v = u'=?gbk?Q?Hey_There=2D=8C=8D=BE=B0?='
+    eq_(u'Hey There-實景', encodedword.mime_to_unicode(v))
+
+    v = u'=?gb18030?Q?Hey_There=2D=8C=8D=BE=B0?='
+    eq_(u'Hey There-實景', encodedword.mime_to_unicode(v))
 
     v = parse(u'Тест длинного дисплей нейма <test@example.com>')
     eq_(v.display_name, encodedword.mime_to_unicode(v.ace_display_name))


### PR DESCRIPTION
Occasionally, the encoding for a GBK/GB 18030 string is incorrectly
specified as GB 2312. Since GB 18030 is compatible with GB 2312 and
GBK, we can use that.

Fixes https://github.com/mailgun/flanker/issues/80