### PR TITLE
Fix two syntax warnings

### DIFF
--- a/flanker/addresslib/plugins/gmail.py
+++ b/flanker/addresslib/plugins/gmail.py
@@ -1,6 +1,6 @@
 # coding:utf-8
 
-'''
+r'''
     Email address validation plugin for gmail.com email addresses.
 
     Notes:

--- a/flanker/mime/message/headers/wrappers.py
+++ b/flanker/mime/message/headers/wrappers.py
@@ -182,7 +182,7 @@ class MessageId(str):
 
 
 class Subject(six.text_type):
-    RE_RE = re.compile("((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
+    RE_RE = re.compile(r"((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)
 
     def __new__(cls, *args, **kw):
         return six.text_type.__new__(cls, *args, **kw)


### PR DESCRIPTION
Fix two syntax warnings, both recent 3.12 additions.

```
../venv/lib/python3.12/site-packages/flanker/mime/message/headers/wrappers.py:185
  /home/closeio/venv/lib/python3.12/site-packages/flanker/mime/message/headers/wrappers.py:185: SyntaxWarning: invalid escape sequence '\d'
    RE_RE = re.compile("((RE|FW|FWD|HA)([[]\d])*:\s*)*", re.I)

../venv/lib/python3.12/site-packages/flanker/addresslib/plugins/gmail.py:3
  /home/closeio/venv/lib/python3.12/site-packages/flanker/addresslib/plugins/gmail.py:3: SyntaxWarning: invalid escape sequence '\-'
    '''
```